### PR TITLE
Fix JSCS unsupported rule error

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -15,9 +15,7 @@
      "allowComments": true,
      "allowRegex": true
   },
-  "validateJSDoc": {
-    "checkParamNames": false,
-    "checkRedundantParams": false,
+  "jsDoc": {
     "requireParamTypes": true
   }
 }


### PR DESCRIPTION
Replace 'validateJSDoc' rule with 'jsDoc'. 'validateJSDoc' was
deprecated in v1.7.0.

In related news, JSCS was recently deprecated in favor of ESlint
so .jscrc can be removed once features have been rolled over.
